### PR TITLE
Fix example to work with broken OSX ipv6 multicast

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,12 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <!-- On OSX IPV6 multicast discovery is broken: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=7122846 -->
+                <configuration>
+                    <jvmArguments>
+                        -Djava.net.preferIPv4Stack=true
+                    </jvmArguments>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Because of the issue described [here](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=7122846), **IPv6 multicast does not work on OSX** breaking this and other hazelcast examples from working.   A parameter must be passed to the JVM to prefer the IPv4 network stack.   This PR does that.   I don't think it will break anything on Linux or Windows, but I haven't tested it there.